### PR TITLE
Feat: persist authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,14 +104,15 @@ The following environment variables need be set:
 
 In addition, the following _optional_ environment variables can be set:
 
-| Env variable             | Default Value | Description                                                     |
-| ------------------------ | ------------- | --------------------------------------------------------------- |
-| `EXPIRES_IN_SEC`         | `86400`       | Expiration of JWT (in seconds)                                  |
-| `INITIAL_ADMIN_USERNAME` |               | Create initial admin user with this username                    |
-| `INITIAL_ADMIN_PASSWORD` |               | Password for initial admin user                                 |
-| `LOG_LEVEL`              | `info`        | Log level of the app                                            |
-| `LOKI_HOST`              |               | Hostname for Grafana Loki to send logs to                       |
-| `LOKI_BASIC_AUTH`        |               | Authentication credentials (basic auth format) for Grafana Loki |
+| Env variable             | Default Value | Description                                                                    |
+| ------------------------ | ------------- | ------------------------------------------------------------------------------ |
+| `EXPIRES_IN_SEC`         | `86400`       | Expiration of JWT (in seconds)                                                 |
+| `INITIAL_ADMIN_USERNAME` |               | Create initial admin user with this username                                   |
+| `INITIAL_ADMIN_PASSWORD` |               | Password for initial admin user                                                |
+| `LOG_LEVEL`              | `info`        | Log level of the app                                                           |
+| `LOKI_HOST`              |               | Hostname for Grafana Loki to send logs to                                      |
+| `LOKI_BASIC_AUTH`        |               | Authentication credentials (basic auth format) for Grafana Loki                |
+| `USE_HTTPS`              | `true`        | Set if HTTPS should enforced for session cookies (only disable in development) |
 
 ## ⌨️ Development
 

--- a/app/controller/user.js
+++ b/app/controller/user.js
@@ -120,6 +120,7 @@ const generateToken = (user) => {
         {
             id: user.id,
             username: user.username,
+            isAdmin: user.isAdmin,
         },
         process.env.JWT_SECRET,
         {

--- a/app/route/auth.js
+++ b/app/route/auth.js
@@ -51,7 +51,9 @@ router.post("/login", (req, res) => {
             res.cookie("token", token, {
                 maxAge: (process.env.EXPIRES_IN_SEC || 86400) * 1000,
                 httpOnly: true,
-                secure: process.env.USE_HTTPS || true,
+                secure: process.env.USE_HTTPS
+                    ? process.env.USE_HTTPS !== "false"
+                    : true,
                 sameSite: "strict",
             })
             return res.json({
@@ -64,6 +66,19 @@ router.post("/login", (req, res) => {
         })
     })(req, res)
 })
+
+/**
+ * Log-out the current user by destroying its token cookie
+ */
+router.post(
+    "/logout",
+    passport.authenticate("jwt", { session: false }),
+    (_, res) => {
+        res.clearCookie("token")
+
+        return res.status(204).send()
+    }
+)
 
 /**
  * Get information about the current user

--- a/app/route/auth.js
+++ b/app/route/auth.js
@@ -48,6 +48,12 @@ router.post("/login", (req, res) => {
             const token = userController.generateToken(user)
 
             logger.verbose("auth_successful", { uid: user.id })
+            res.cookie("token", token, {
+                maxAge: (process.env.EXPIRES_IN_SEC || 86400) * 1000,
+                httpOnly: true,
+                secure: process.env.USE_HTTPS || true,
+                sameSite: "strict",
+            })
             return res.json({
                 user: {
                     username: user.username,
@@ -69,6 +75,7 @@ router.get(
         return res.json({
             user: {
                 username: req.user.username,
+                isAdmin: req.user.isAdmin,
             },
         })
     }

--- a/app/util/passportStrategies.js
+++ b/app/util/passportStrategies.js
@@ -9,6 +9,10 @@ import mongoose from "mongoose"
 
 const User = mongoose.model("User")
 
+const getJwt = (req) => {
+    return req.cookies.token || ExtractJwt.fromAuthHeaderAsBearerToken()(req)
+}
+
 passport.use(
     new LocalStrategy(async (username, password, done) => {
         let user
@@ -37,7 +41,7 @@ passport.use(
 passport.use(
     new JwtStrategy(
         {
-            jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+            jwtFromRequest: getJwt,
             secretOrKey: process.env.JWT_SECRET,
         },
         (jwtPayload, done) => {
@@ -54,7 +58,7 @@ passport.use(
     "jwt_admin",
     new JwtStrategy(
         {
-            jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+            jwtFromRequest: getJwt,
             secretOrKey: process.env.JWT_SECRET,
         },
         async (jwtPayload, done) => {

--- a/app/util/s3Storage.js
+++ b/app/util/s3Storage.js
@@ -11,5 +11,7 @@ export const s3Client = new S3Client({
         accessKeyId: process.env.S3_ACCESS_KEY,
         secretAccessKey: process.env.S3_ACCESS_SECRET,
     },
-    forcePathStyle: process.env.S3_FORCE_PATH_STYLE || false,
+    forcePathStyle: process.env.S3_FORCE_PATH_STYLE
+        ? process.env.S3_FORCE_PATH_STYLE === "true"
+        : false,
 })

--- a/appInit.js
+++ b/appInit.js
@@ -3,6 +3,7 @@
  */
 
 import express from "express"
+import cookieParser from "cookie-parser"
 import cors from "cors"
 import morgan from "morgan"
 import "dotenv/config"
@@ -16,7 +17,9 @@ import logger from "./app/util/logger.js"
 let app = express()
 
 app.set("query parser", "extended")
+
 app.use(express.json())
+app.use(cookieParser())
 
 /* Database connection */
 

--- a/client/src/component/Navbar.jsx
+++ b/client/src/component/Navbar.jsx
@@ -2,10 +2,12 @@
  * Colly | app navigation bar
  */
 
+import { useEffect } from "react"
 import { useNavigate, Link } from "react-router-dom"
 import usePrefersColorScheme from "use-prefers-color-scheme"
 
 import { useUserAuth } from "./../component/context/UserAuthProvider"
+import { getMe } from "./../logic/api/auth"
 import collyLogoImg from "./../asset/colly-logo.png"
 
 import "./Navbar.css"
@@ -20,8 +22,14 @@ function Navbar({
     const prefersColorScheme = usePrefersColorScheme()
     const isDarkMode = prefersColorScheme === "dark"
 
-    const [, setAccessToken, displayName, setDisplayName, isAdmin, setIsAdmin] =
-        useUserAuth()
+    const [
+        accessToken,
+        setAccessToken,
+        displayName,
+        setDisplayName,
+        isAdmin,
+        setIsAdmin,
+    ] = useUserAuth()
 
     const handleCreateTag = (e) => {
         e.preventDefault()
@@ -48,6 +56,30 @@ function Navbar({
 
         navigate("/login")
     }
+
+    /**
+     * Check if user information is available due to previous authentication,
+     * otherwise, fetch it from the API endpoint
+     */
+    const checkUserInfoAvailable = async () => {
+        if (displayName !== "...") {
+            return
+        }
+
+        let user
+        try {
+            user = await getMe(accessToken)
+        } catch {
+            return
+        }
+
+        setDisplayName(user.username)
+        setIsAdmin(user.isAdmin)
+    }
+
+    useEffect(() => {
+        checkUserInfoAvailable()
+    }, [])
 
     return (
         <nav

--- a/client/src/component/Navbar.jsx
+++ b/client/src/component/Navbar.jsx
@@ -5,9 +5,10 @@
 import { useEffect } from "react"
 import { useNavigate, Link } from "react-router-dom"
 import usePrefersColorScheme from "use-prefers-color-scheme"
+import { toast } from "react-toastify"
 
 import { useUserAuth } from "./../component/context/UserAuthProvider"
-import { getMe } from "./../logic/api/auth"
+import { getMe, logout } from "./../logic/api/auth"
 import collyLogoImg from "./../asset/colly-logo.png"
 
 import "./Navbar.css"
@@ -31,6 +32,41 @@ function Navbar({
         setIsAdmin,
     ] = useUserAuth()
 
+    /**
+     * Check if user information is available due to previous authentication,
+     * otherwise, fetch it from the API endpoint
+     */
+    const checkUserInfoAvailable = async () => {
+        if (displayName !== "...") {
+            return
+        }
+
+        let user
+        try {
+            user = await getMe(accessToken)
+        } catch {
+            return
+        }
+
+        setDisplayName(user.username)
+        setIsAdmin(user.isAdmin)
+    }
+
+    const doLogout = async () => {
+        try {
+            await logout(accessToken)
+        } catch {
+            toast.error("Log-out on server failed!")
+            return
+        }
+
+        setAccessToken(null)
+        setDisplayName("...")
+        setIsAdmin(false)
+
+        navigate("/login")
+    }
+
     const handleCreateTag = (e) => {
         e.preventDefault()
 
@@ -50,31 +86,7 @@ function Navbar({
     const handleLogoutClick = (e) => {
         e.preventDefault()
 
-        setAccessToken(null)
-        setDisplayName("...")
-        setIsAdmin(false)
-
-        navigate("/login")
-    }
-
-    /**
-     * Check if user information is available due to previous authentication,
-     * otherwise, fetch it from the API endpoint
-     */
-    const checkUserInfoAvailable = async () => {
-        if (displayName !== "...") {
-            return
-        }
-
-        let user
-        try {
-            user = await getMe(accessToken)
-        } catch {
-            return
-        }
-
-        setDisplayName(user.username)
-        setIsAdmin(user.isAdmin)
+        doLogout()
     }
 
     useEffect(() => {

--- a/client/src/component/context/DataProvider.jsx
+++ b/client/src/component/context/DataProvider.jsx
@@ -33,7 +33,11 @@ const AppDataProvider = (props) => {
         let items
         try {
             items = await findItems(accessToken, query)
-        } catch {
+        } catch (e) {
+            if (e.message === "unauthorized") {
+                throw e
+            }
+
             return
         }
 
@@ -44,7 +48,11 @@ const AppDataProvider = (props) => {
         let users
         try {
             users = await findUsers(accessToken, query)
-        } catch {
+        } catch (e) {
+            if (e.message === "unauthorized") {
+                throw e
+            }
+
             return
         }
 

--- a/client/src/logic/api/auth.js
+++ b/client/src/logic/api/auth.js
@@ -1,0 +1,28 @@
+/**
+ * Colly | auth API logic
+ */
+
+import InternalAPI from "./../../util/InternalAPI"
+import { checkRequestSuccessful } from "./util/requestHelper"
+
+/**
+ * Get information about current user
+ * @param {string} accessToken API access token
+ * @returns {Array} user objects
+ */
+export const getMe = async (accessToken) => {
+    const resp = await fetch(`${InternalAPI.API_ENDPOINT}/auth/me`, {
+        method: "GET",
+        headers: {
+            Authorization: `Bearer ${accessToken}`,
+        },
+    })
+    checkRequestSuccessful(resp)
+    const res = await resp.json()
+
+    if (res.error) {
+        throw new Error(res.error_code)
+    }
+
+    return res.user
+}

--- a/client/src/logic/api/auth.js
+++ b/client/src/logic/api/auth.js
@@ -8,7 +8,7 @@ import { checkRequestSuccessful } from "./util/requestHelper"
 /**
  * Get information about current user
  * @param {string} accessToken API access token
- * @returns {Array} user objects
+ * @returns {object} user information
  */
 export const getMe = async (accessToken) => {
     const resp = await fetch(`${InternalAPI.API_ENDPOINT}/auth/me`, {
@@ -25,4 +25,18 @@ export const getMe = async (accessToken) => {
     }
 
     return res.user
+}
+
+/**
+ * Log-out the current user session
+ * @param {string} accessToken API access token
+ */
+export const logout = async (accessToken) => {
+    const resp = await fetch(`${InternalAPI.API_ENDPOINT}/auth/logout`, {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${accessToken}`,
+        },
+    })
+    checkRequestSuccessful(resp)
 }

--- a/client/src/logic/api/item.js
+++ b/client/src/logic/api/item.js
@@ -5,6 +5,7 @@
 import qs from "qs"
 
 import InternalAPI from "./../../util/InternalAPI"
+import { checkRequestSuccessful } from "./util/requestHelper"
 import { generateValidationErrorMessage } from "./util/errorCodeHandling"
 
 /**
@@ -111,24 +112,17 @@ export const findItems = async (accessToken, query) => {
         encode: false,
     })
 
-    let res
-    try {
-        const resp = await fetch(
-            `${InternalAPI.API_ENDPOINT}/item?${queryStr}`,
-            {
-                method: "GET",
-                headers: {
-                    Authorization: `Bearer ${accessToken}`,
-                },
-            }
-        )
-        res = await resp.json()
-    } catch {
-        throw new Error()
-    }
+    const resp = await fetch(`${InternalAPI.API_ENDPOINT}/item?${queryStr}`, {
+        method: "GET",
+        headers: {
+            Authorization: `Bearer ${accessToken}`,
+        },
+    })
+    checkRequestSuccessful(resp)
+    const res = await resp.json()
 
     if (res.error) {
-        throw new Error()
+        throw new Error(res.error_code)
     }
 
     return res.data

--- a/client/src/logic/api/user.js
+++ b/client/src/logic/api/user.js
@@ -5,6 +5,7 @@
 import qs from "qs"
 
 import InternalAPI from "./../../util/InternalAPI"
+import { checkRequestSuccessful } from "./util/requestHelper"
 import { generateValidationErrorMessage } from "./util/errorCodeHandling"
 
 /**
@@ -115,24 +116,17 @@ export const findUsers = async (accessToken, query) => {
         encode: false,
     })
 
-    let res
-    try {
-        const resp = await fetch(
-            `${InternalAPI.API_ENDPOINT}/user?${queryStr}`,
-            {
-                method: "GET",
-                headers: {
-                    Authorization: `Bearer ${accessToken}`,
-                },
-            }
-        )
-        res = await resp.json()
-    } catch {
-        throw new Error()
-    }
+    const resp = await fetch(`${InternalAPI.API_ENDPOINT}/user?${queryStr}`, {
+        method: "GET",
+        headers: {
+            Authorization: `Bearer ${accessToken}`,
+        },
+    })
+    checkRequestSuccessful(resp)
+    const res = await resp.json()
 
     if (res.error) {
-        throw new Error()
+        throw new Error(res.error_code)
     }
 
     return res.data

--- a/client/src/logic/api/util/requestHelper.js
+++ b/client/src/logic/api/util/requestHelper.js
@@ -1,0 +1,18 @@
+/**
+ * Colly | shared code for fetch requests to the API
+ */
+
+/**
+ * Check if response of fetch request was successful
+ * @param {object} resp fetch response
+ */
+export const checkRequestSuccessful = (resp) => {
+    if (!resp.ok) {
+        switch (resp.status) {
+            case 401:
+                throw new Error("unauthorized")
+            default:
+                throw new Error("request_unsuccessful")
+        }
+    }
+}

--- a/client/src/page/Admin.jsx
+++ b/client/src/page/Admin.jsx
@@ -47,14 +47,16 @@ function Admin() {
         loadUsers()
     }
 
-    useEffect(() => {
-        if (accessToken === null) {
+    const triggerUserLoad = async () => {
+        try {
+            await loadUsers()
+        } catch {
             navigate("/login")
-
-            return
         }
+    }
 
-        loadUsers()
+    useEffect(() => {
+        triggerUserLoad()
     }, [accessToken])
 
     return (

--- a/client/src/page/Dashboard.jsx
+++ b/client/src/page/Dashboard.jsx
@@ -30,25 +30,23 @@ function Dashboard() {
     const createItemModalRef = useRef()
     const preferencesModalRef = useRef()
 
-    const triggerItemLoad = () => {
-        if (tagId) {
-            loadItems({
-                filter: {
-                    tags: tagId,
-                },
-            })
-        } else {
-            loadItems()
+    const triggerItemLoad = async () => {
+        try {
+            if (tagId) {
+                await loadItems({
+                    filter: {
+                        tags: tagId,
+                    },
+                })
+            } else {
+                await loadItems()
+            }
+        } catch {
+            navigate("/login")
         }
     }
 
     useEffect(() => {
-        if (accessToken === null) {
-            navigate("/login")
-
-            return
-        }
-
         triggerItemLoad()
     }, [accessToken, tagId])
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "@aws-sdk/client-s3": "^3.511.0",
         "@aws-sdk/s3-request-presigner": "^3.511.0",
         "bcrypt": "^6.0.0",
+        "cookie-parser": "^1.4.7",
         "dotenv": "^17.0.0",
         "express": "^5.0.0",
         "jsonwebtoken": "^9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2857,6 +2857,7 @@ __metadata:
     bcrypt: "npm:^6.0.0"
     c8: "npm:^10.0.0"
     chai: "npm:^5.0"
+    cookie-parser: "npm:^1.4.7"
     cors: "npm:^2.8"
     dotenv: "npm:^17.0.0"
     eslint: "npm:^9.23.0"
@@ -3021,6 +3022,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cookie-parser@npm:^1.4.7":
+  version: 1.4.7
+  resolution: "cookie-parser@npm:1.4.7"
+  dependencies:
+    cookie: "npm:0.7.2"
+    cookie-signature: "npm:1.0.6"
+  checksum: 10c0/46bef553de409031b69a6074ce512d131a98e4fa12612669f1a9c3dd98d56897a31db86a3f4338d4a3a895c6f8d5cfd6fa4d99cdf588e0e8eda655efc3f384dc
+  languageName: node
+  linkType: hard
+
+"cookie-signature@npm:1.0.6":
+  version: 1.0.6
+  resolution: "cookie-signature@npm:1.0.6"
+  checksum: 10c0/b36fd0d4e3fef8456915fcf7742e58fbfcc12a17a018e0eb9501c9d5ef6893b596466f03b0564b81af29ff2538fd0aa4b9d54fe5ccbfb4c90ea50ad29fe2d221
+  languageName: node
+  linkType: hard
+
 "cookie-signature@npm:^1.2.1":
   version: 1.2.2
   resolution: "cookie-signature@npm:1.2.2"
@@ -3028,7 +3046,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:^0.7.1":
+"cookie@npm:0.7.2, cookie@npm:^0.7.1":
   version: 0.7.2
   resolution: "cookie@npm:0.7.2"
   checksum: 10c0/9596e8ccdbf1a3a88ae02cf5ee80c1c50959423e1022e4e60b91dd87c622af1da309253d8abdb258fb5e3eacb4f08e579dc58b4897b8087574eee0fd35dfa5d2


### PR DESCRIPTION
Prevent the user being forced to authenticate after each page reload by storing the JWT token in a server-side cookie that is sent along with each request from the client. The bearer token auth method is still available for using the API anywhere outside a web browser.